### PR TITLE
Fix user dopdown menu

### DIFF
--- a/backend_theme_v10/static/src/less/style.less
+++ b/backend_theme_v10/static/src/less/style.less
@@ -347,3 +347,9 @@ textarea, select, .o_form_view.o_form_editable .o_form_field_many2manytags,
   	text-align: left;
       }
 }
+
+.main-nav .navbar-right .navbar-nav .open .dropdown-menu {
+	@media (max-width: 767px) {
+		background: #337AB7!important;
+	}
+}


### PR DESCRIPTION
On mobile the user dorpdown menu (.navbar-right) inherits color from web_responsibe which is white the same color than the menu font.
This fix changes background to match theme color.

![diff](https://user-images.githubusercontent.com/7444518/38588728-a73e3b9c-3ce4-11e8-8ec7-e0a2209b79f5.png)