### PR TITLE
Bigger sidebar icons like Ubuntu Unity style, remove sidebar menu names(shown as tooltip)

### DIFF
--- a/backend_theme_v10/static/src/less/sidebar.less
+++ b/backend_theme_v10/static/src/less/sidebar.less
@@ -3,7 +3,7 @@
 
 /* App Sidebar Panel */
 
-@odoo-sidebar-width: 180px;
+@odoo-sidebar-width: 76px;
 
 .app-sidebar-panel {
     .o-flex(0, 0, @odoo-sidebar-width);
@@ -53,9 +53,7 @@
 }
 
 .app-sidebar-menuitem {
-    width: 23px;
-    height: 22px;
-    margin-right: 5px;
+    width: 100%;
 }
 
 .toggle-sidebar {

--- a/backend_theme_v10/views/sidebar.xml
+++ b/backend_theme_v10/views/sidebar.xml
@@ -20,9 +20,6 @@
                                t-att-data-action-model="menu['action'] and menu['action'].split(',')[0] or None"
                                t-att-data-action-id="menu['action'] and menu['action'].split(',')[1] or None">
                                 <img t-attf-src="/web/image/ir.ui.menu/{{ menu['id'] }}/web_icon_data" t-att-alt="menu['name']" class="app-sidebar-menuitem" t-att-title="menu['name']"/>
-                                <span class="title" >
-                                    <t t-esc="menu['name']"/>
-                                </span>
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
Fix https://github.com/Openworx/backend_theme/issues/47