### PR TITLE
[FIX] Bottom bar background color for list views moved from gray to main background color (blue)

### DIFF
--- a/backend_theme_v11/static/src/less/form_view.less
+++ b/backend_theme_v11/static/src/less/form_view.less
@@ -1,0 +1,12 @@
+// Sticky Header & Footer in List View
+.o_view_manager_content {
+    >div {
+        >.table-responsive {
+            >.o_list_view {
+                tfoot tr:nth-child(1) td {
+                    background-color: @odoo-brand-primary;
+                }
+            }
+        }
+    }
+}

--- a/backend_theme_v11/views/assets.xml
+++ b/backend_theme_v11/views/assets.xml
@@ -12,6 +12,7 @@
 			<xpath expr=".">
 				<link rel="stylesheet" href="/backend_theme_v11/static/src/less/drawer.less"/>
 				<link rel="stylesheet" href="/backend_theme_v11/static/src/less/variables.less"/>
+				<link rel="stylesheet" href="/backend_theme_v11/static/src/less/form_view.less" />
 				<link rel="stylesheet" href="/backend_theme_v11/static/src/less/bootswatch.less"/>
 				<link rel="stylesheet" href="/backend_theme_v11/static/src/less/style.less"/>
 				<link rel="stylesheet" href="/backend_theme_v11/static/src/less/sidebar.less"/>


### PR DESCRIPTION
We faced this issue after a recent OCA/web repository update. With this PR the bottom bar in a list view (usually with the sum/avg data) recovers the original background color (blue). With the current color (light gray) and white forecolor, it's very difficult to see print data.