### PR TITLE
Fix user dopdown menu

### DIFF
--- a/backend_theme_v11/static/src/less/style.less
+++ b/backend_theme_v11/static/src/less/style.less
@@ -288,3 +288,9 @@ textarea, select, .o_form_view.o_form_editable .o_form_field_many2manytags,
 	text-align: left;
     }
 }
+
+.main-nav .navbar-right .navbar-nav .open .dropdown-menu {
+	@media (max-width: 767px) {
+		background: #337AB7!important;
+	}
+}


### PR DESCRIPTION
Same PR as #53 for v11

On mobile the user dorpdown menu (.navbar-right) inherits color from web_responsibe which is white the same color than the menu font.