### PR TITLE
Calculate oe_title width to let space for avatar on the right

### DIFF
--- a/backend_theme_v12/static/src/scss/style.scss
+++ b/backend_theme_v12/static/src/scss/style.scss
@@ -286,15 +286,15 @@ textarea, select, .o_form_view.o_form_editable .o_form_field_many2manytags,
 .o_list_view.table thead, .o_list_view.table tfoot, .o_list_view.table td,.o_list_view.table th {
     border: none;
 }
- 
+
 .o_list_view.table thead {
     background-color: #e2e2e0;
 }
- 
+
 .o_list_view.table thead > tr > th.o_column_sortable:hover {
     background-color: #D6D6D3;
 }
- 
+
 .o_list_view.table tbody tr.o_group_header {
     background-color: #dfdfdf;
     background-image: none;
@@ -343,11 +343,11 @@ textarea, select, .o_form_view.o_form_editable .o_form_field_many2manytags,
             border: 1px solid #d9d7d7;
             box-shadow: 0 5px 20px -15px black;
         }
-    } 
+    }
 
     .o_form_statusbar {
         //margin: -16px;
-  
+
         .o_statusbar_status {
             > .o_arrow_button {
                 background: #ffffff;
@@ -471,4 +471,22 @@ $o-statbutton-spacing: 6px;
             padding-left: 0px;
         }
     }
+
+}
+
+// Override `@include media-breakpoint-up` in module `web_responsive`
+@include media-breakpoint-up(md) {
+    .o_form_view .oe_button_box + .oe_avatar + .oe_title {
+      /* Add 110px in the calculation for the avatar space */
+      width: calc(100% - 400px - 110px);
+      min-width: 400px;
+      max-width: 650px;
+    }
+    /* Same correction for res.users .oe_title div */
+    .o_form_view .o_field_integer + .oe_button_box + .o_form_header + .o_field_boolean +
+    .o_form_header + .oe_avatar + .oe_title {
+      width: calc(100% - 400px - 110px);
+      min-width: 400px;
+      max-width: 650px;
+    }    
 }


### PR DESCRIPTION
Hi @mgielissen ,

I've just used your latest **backend_theme_v12** module today and even if at first I was surprised by the avatar on the right, I think it's quite a good improvement for the majority of the partners who will never have pictures.

However I noticed that you modified the `oe_title` class with [no padding on the right](https://github.com/Openworx/backend_theme/commit/f41006ae438f40a6b71145cb401468216400340b#diff-8856a99f3b03e9c6655c8411f8ca3bebR470), which leave a big blank space in Edit mode :
![image](https://user-images.githubusercontent.com/31664455/84965121-6adb2400-b0e4-11ea-99f5-2db303756048.png)

So in this PR I would suggest to override the [calculation made on the web_responsive module](https://github.com/OCA/web/blob/13.0/web_responsive/static/src/css/web_responsive.scss#L22) for long `oe_title` width and subtract more 110px for the avatar space :
![image](https://user-images.githubusercontent.com/31664455/84965382-28fead80-b0e5-11ea-82c1-7eae85664b37.png)

Hope you agree with it !

Regards,