### PR TITLE
makes backend_theme_v14 depends on OCA web_responsive

### DIFF
--- a/backend_theme_v14/__manifest__.py
+++ b/backend_theme_v14/__manifest__.py
@@ -19,7 +19,7 @@
     "installable": True,
     "depends": [
         'web',
-        'ow_web_responsive',
+        'web_responsive',
 
     ],
     "data": [
@@ -31,4 +31,3 @@
     #'live_test_url': 'https://youtu.be/JX-ntw2ORl8'
 
 }
-


### PR DESCRIPTION
Hi @mgielissen ,

I create this PR because OCA module web_responsive has been migrated and will be merged soon : https://github.com/OCA/web/pull/1819
I let you merge it whenever you think it will be the right time for you.